### PR TITLE
Add support for expanding relevant VS Code Predefined Variables

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,11 +6,25 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "Run Extension",
+			"name": "Run Extension (Multifolder)",
 			"type": "extensionHost",
 			"request": "launch",
 			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"${workspaceFolder}/test/multi-folder/multi-folder-workspace.code-workspace"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "${defaultBuildTask}"
+		},
+		{
+			"name": "Run Extension (Single Folder)",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"${workspaceFolder}/test/single-folder"
 			],
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Some [VS Code Predefined Variables](https://code.visualstudio.com/docs/reference
 - `${userHome}`: The path to your home directory.
 - `${workspaceFolder}`: The absolute path to the first workspace folder.
 - `${workspaceFolderBasename}`: The name of the first workspace folder.
-- `${cwd}`: The current working directory.
 - `${pathSeparator}` or `${/}`: The platform-specific path separator (`/` on macOS/Linux, `\\` on Windows).
 - `${env:VARNAME}`: The value of the environment variable `VARNAME`.
 - `${workspaceFolder:FolderName}`: The absolute path to the workspace folder named `FolderName`.

--- a/README.md
+++ b/README.md
@@ -35,3 +35,17 @@ Due to how Visual Studio Code's APIs work the text to link cannot span multiple 
 This extension is an early version that seems to work but may well contain bugs. Please
 [file an issue](https://github.com/Mossop/terminal-links/issues) if you run into a problem or have a
 suggestion for improvements.
+
+## Supported Variables for URI Expansion
+
+Some [VS Code Predefined Variables](https://code.visualstudio.com/docs/reference/variables-reference#_predefined-variables) are supported. You can use these variables in the `uri` field of your matcher configuration. The following variables are supported:
+
+- `${userHome}`: The path to your home directory.
+- `${workspaceFolder}`: The absolute path to the first workspace folder.
+- `${workspaceFolderBasename}`: The name of the first workspace folder.
+- `${cwd}`: The current working directory.
+- `${pathSeparator}` or `${/}`: The platform-specific path separator (`/` on macOS/Linux, `\\` on Windows).
+- `${env:VARNAME}`: The value of the environment variable `VARNAME`.
+- `${workspaceFolder:FolderName}`: The absolute path to the workspace folder named `FolderName`.
+- `${workspaceFolderBasename:FolderName}`: The name of the workspace folder named `FolderName`.
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,17 +79,17 @@ function parseConfig() {
   );
 
   let matchers = config.get("matchers") ?? [];
-  CHANNEL?.info("Parsing config:\n" + JSON.stringify(matchers, null, 2));
+  CHANNEL?.info("Parsing config:\n" + JSON.stringify(matchers ?? [], null, 2));
   try {
     parseMatchers(matchers);
   } catch (e) {
-    CHANNEL?.error(e as string | Error);
+    CHANNEL?.error((e as Error));
     return;
   }
 
   CHANNEL?.trace(
     "Parsed config:\n" +
-      LINKS.map((config, i) =>
+      LINKS.map((config) =>
         `  {\n    regex: "${config.regex.source}",\n    uri: "${config.uriPattern}"\n  }`
       ).join("\n")
   );
@@ -159,23 +159,23 @@ export function deactivate() {
 
 function expandVariables(input: string): string {
   // Collect workspace info
-  const wsFolders = workspace.workspaceFolders || [];
-  const wsFolder = wsFolders[0] || undefined;
-  const wsPath = wsFolder?.uri.fsPath || "";
+  const wsFolders = workspace.workspaceFolders ?? [];
+  const wsFolder = wsFolders[0] ?? undefined;
+  const wsPath = wsFolder?.uri.fsPath ?? "";
   const wsBasename = wsFolder ? path.basename(wsFolder.uri.fsPath) : "";
-  const userHome = process.env.HOME || process.env.USERPROFILE || "";
+  const userHome = process.env.HOME ?? process.env.USERPROFILE ?? "";
   const cwd = process.cwd();
   const pathSeparator = path.sep;
 
   CHANNEL?.trace(`[expandVariables] input: ${input}`);
 
   function envVar(name: string): string {
-    return process.env[name] || "";
+    return process.env[name] ?? "";
   }
 
   function getWorkspaceFolderPath(name: string): string {
     const folder = wsFolders.find(f => path.basename(f.uri.fsPath) === name || f.name === name);
-    return folder ? folder.uri.fsPath : "";
+    return folder?.uri.fsPath ?? "";
   }
   function getWorkspaceFolderBasename(name: string): string {
     const folder = wsFolders.find(f => path.basename(f.uri.fsPath) === name || f.name === name);
@@ -190,10 +190,10 @@ function expandVariables(input: string): string {
     .replace(/\${cwd}/g, cwd)
     .replace(/\${pathSeparator}/g, pathSeparator)
     .replace(/\${\/}/g, pathSeparator)
-    .replace(/\${env:([A-Za-z0-9_]+)}/g, (_, name) => envVar(name))
+    .replace(/\${env:([A-Za-z0-9_]+)}/g, (_, name: string) => envVar(name))
     // Scoped per workspace folder: ${workspaceFolder:FolderName}
-    .replace(/\${workspaceFolder:([^}]+)}/g, (_, name) => getWorkspaceFolderPath(name))
-    .replace(/\${workspaceFolderBasename:([^}]+)}/g, (_, name) => getWorkspaceFolderBasename(name));
+    .replace(/\${workspaceFolder:([^}]+)}/g, (_, name: string) => getWorkspaceFolderPath(name))
+    .replace(/\${workspaceFolderBasename:([^}]+)}/g, (_, name: string) => getWorkspaceFolderBasename(name));
 
   CHANNEL?.trace(`[expandVariables] result: ${result}`);
   return result;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,7 +164,6 @@ function expandVariables(input: string): string {
   const wsPath = wsFolder?.uri.fsPath ?? "";
   const wsBasename = wsFolder ? path.basename(wsFolder.uri.fsPath) : "";
   const userHome = process.env.HOME ?? process.env.USERPROFILE ?? "";
-  const cwd = process.cwd();
   const pathSeparator = path.sep;
 
   CHANNEL?.trace(`[expandVariables] input: ${input}`);
@@ -187,7 +186,6 @@ function expandVariables(input: string): string {
     .replace(/\${userHome}/g, userHome)
     .replace(/\${workspaceFolder}/g, wsPath)
     .replace(/\${workspaceFolderBasename}/g, wsBasename)
-    .replace(/\${cwd}/g, cwd)
     .replace(/\${pathSeparator}/g, pathSeparator)
     .replace(/\${\/}/g, pathSeparator)
     .replace(/\${env:([A-Za-z0-9_]+)}/g, (_, name: string) => envVar(name))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,8 +23,7 @@ class FoundLink extends TerminalLink {
   #uri: Uri;
 
   constructor(startIndex: number, length: number, uri: Uri) {
-    super(startIndex, length, uri.toString());
-
+    super(startIndex, length, uri.toString(true)); // Do not encode the URI in tooltips
     this.#uri = uri;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import {
   ConfigurationChangeEvent,
   LogOutputChannel,
 } from "vscode";
+import * as path from "path";
 
 interface Config {
   regex: RegExp;
@@ -16,6 +17,7 @@ interface Config {
 }
 
 let LINKS: Config[] = [];
+let CHANNEL: LogOutputChannel;
 
 class FoundLink extends TerminalLink {
   #uri: Uri;
@@ -64,42 +66,45 @@ function parseMatchers(matchers: unknown) {
 
     foundLinks.push({
       regex: new RegExp(asString(item, "regex"), "g"),
-      uriPattern: asString(item, "uri"),
+      uriPattern: expandVariables(asString(item, "uri")),
     });
   }
 
   LINKS = foundLinks;
 }
 
-function parseConfig(channel: LogOutputChannel) {
+function parseConfig() {
   let config = workspace.getConfiguration(
     "terminalLinks",
     workspace.workspaceFile
   );
 
   let matchers = config.get("matchers") ?? [];
-  console.log(`Parsing config ${JSON.stringify(matchers)}`);
+  CHANNEL?.info("Parsing config:\n" + JSON.stringify(matchers, null, 2));
   try {
     parseMatchers(matchers);
   } catch (e) {
-    channel.error(e as string | Error);
+    CHANNEL?.error(e as string | Error);
     return;
   }
 
-  channel.trace(
-    `Parsed config: ${JSON.stringify(LINKS.map((config) => ({ ...config, regex: config.regex.source })))}`
+  CHANNEL?.trace(
+    "Parsed config:\n" +
+      LINKS.map((config, i) =>
+        `  {\n    regex: "${config.regex.source}",\n    uri: "${config.uriPattern}"\n  }`
+      ).join("\n")
   );
 }
 
 export function activate(context: ExtensionContext) {
-  let channel = window.createOutputChannel("Terminal Links", { log: true });
-  channel.info("Activated");
+  CHANNEL = window.createOutputChannel("Terminal Links", { log: true });
+  CHANNEL.info("Activated");
 
-  parseConfig(channel);
+  parseConfig();
   context.subscriptions.push(
     workspace.onDidChangeConfiguration((e: ConfigurationChangeEvent) => {
       if (e.affectsConfiguration("terminalLinks", workspace.workspaceFile)) {
-        parseConfig(channel);
+        parseConfig();
       }
     }, null)
   );
@@ -119,7 +124,7 @@ export function activate(context: ExtensionContext) {
         let first: [RegExpExecArray, Config] | null = null;
 
         for (let { regex, uriPattern } of LINKS) {
-          channel.trace(`Matching line '${line}' against ${regex.source}`);
+          CHANNEL.trace(`Matching line '${line}' against ${regex.source}`);
           let result = regex.exec(line);
 
           if (result) {
@@ -151,4 +156,46 @@ export function activate(context: ExtensionContext) {
 // This method is called when your extension is deactivated
 export function deactivate() {
   // Nothing to do.
+}
+
+function expandVariables(input: string): string {
+  // Collect workspace info
+  const wsFolders = workspace.workspaceFolders || [];
+  const wsFolder = wsFolders[0] || undefined;
+  const wsPath = wsFolder?.uri.fsPath || "";
+  const wsBasename = wsFolder ? path.basename(wsFolder.uri.fsPath) : "";
+  const userHome = process.env.HOME || process.env.USERPROFILE || "";
+  const cwd = process.cwd();
+  const pathSeparator = path.sep;
+
+  CHANNEL?.trace(`[expandVariables] input: ${input}`);
+
+  function envVar(name: string): string {
+    return process.env[name] || "";
+  }
+
+  function getWorkspaceFolderPath(name: string): string {
+    const folder = wsFolders.find(f => path.basename(f.uri.fsPath) === name || f.name === name);
+    return folder ? folder.uri.fsPath : "";
+  }
+  function getWorkspaceFolderBasename(name: string): string {
+    const folder = wsFolders.find(f => path.basename(f.uri.fsPath) === name || f.name === name);
+    return folder ? path.basename(folder.uri.fsPath) : "";
+  }
+
+  // Replace all supported variables, including scoped per workspace folder
+  const result = input
+    .replace(/\${userHome}/g, userHome)
+    .replace(/\${workspaceFolder}/g, wsPath)
+    .replace(/\${workspaceFolderBasename}/g, wsBasename)
+    .replace(/\${cwd}/g, cwd)
+    .replace(/\${pathSeparator}/g, pathSeparator)
+    .replace(/\${\/}/g, pathSeparator)
+    .replace(/\${env:([A-Za-z0-9_]+)}/g, (_, name) => envVar(name))
+    // Scoped per workspace folder: ${workspaceFolder:FolderName}
+    .replace(/\${workspaceFolder:([^}]+)}/g, (_, name) => getWorkspaceFolderPath(name))
+    .replace(/\${workspaceFolderBasename:([^}]+)}/g, (_, name) => getWorkspaceFolderBasename(name));
+
+  CHANNEL?.trace(`[expandVariables] result: ${result}`);
+  return result;
 }

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,24 @@
+# Test Workspace Guide
+
+## Launch Configurations
+
+Defined in [launch.json](../.vscode/launch.json):
+- Run Extension (Multifolder): Opens a multi-root workspace with two folders (`main-folder` and `another-folder`). Use this to test variable substitution for `${workspaceFolder:FolderName}` and `${workspaceFolderBasename:FolderName}`.
+- Run Extension (Single Folder): Contains a single folder workspace. Use this to test basic variable substitution like `${workspaceFolder}`, `${cwd}`, `${userHome}`, etc.
+
+## How to See Variable Substitutions
+
+**Check the Output Log**
+   - Go to the Output panel (`View` > `Output`).
+   - Select `Terminal Links` from the dropdown.
+   - Enable Trace logs through the filter and channel settings (cog icon)
+   - Look for log lines like:
+     - `[expandVariables] input: ...` — shows the input string with variables.
+     - `[expandVariables] result: ...` — shows the result after variable substitution.
+   - You will also see trace logs for each regex match attempt and the final parsed config.
+
+This allows you to verify that variables in your matcher configuration are being expanded as expected.
+
+---
+
+For more details on supported variables, see the main project [README](../README.md).

--- a/test/multi-folder/another-folder/README.md
+++ b/test/multi-folder/another-folder/README.md
@@ -1,0 +1,3 @@
+# Another Folder
+
+This is a second folder in the multi-folder workspace for testing purposes.

--- a/test/multi-folder/main-folder/README.md
+++ b/test/multi-folder/main-folder/README.md
@@ -1,0 +1,3 @@
+# Example Workspace
+
+This is the main workspace folder for testing the terminal links extension.

--- a/test/multi-folder/multi-folder-workspace.code-workspace
+++ b/test/multi-folder/multi-folder-workspace.code-workspace
@@ -24,10 +24,6 @@
         "uri": "file:${workspaceFolderBasename}/test.txt"
       },
       {
-        "regex": "test_cwd",
-        "uri": "file:cwd:'${cwd}'/test.txt"
-      },
-      {
         "regex": "test_pathSeparator",
         "uri": "file:sep${pathSeparator}"
       },

--- a/test/multi-folder/multi-folder-workspace.code-workspace
+++ b/test/multi-folder/multi-folder-workspace.code-workspace
@@ -1,0 +1,60 @@
+{
+  "folders": [
+    {
+      "name": "Main Folder",
+      "path": "./main-folder"
+    },
+    {
+      "name": "Another Folder",
+      "path": "./another-folder"
+    }
+  ],
+  "settings": {
+    "terminalLinks.matchers": [
+      {
+        "regex": "/(home|opt|Users)\\/[^\\s:]+\\/[^\\s:]+\\.(py|c|rs|cpp)",
+        "uri": "file:${workspaceFolder}/$0"
+      },
+      {
+        "regex": "test_userHome",
+        "uri": "file:${userHome}/test.txt"
+      },
+      {
+        "regex": "test_workspaceFolderBasename",
+        "uri": "file:${workspaceFolderBasename}/test.txt"
+      },
+      {
+        "regex": "test_cwd",
+        "uri": "file:cwd:'${cwd}'/test.txt"
+      },
+      {
+        "regex": "test_pathSeparator",
+        "uri": "file:sep${pathSeparator}"
+      },
+      {
+        "regex": "test_slash",
+        "uri": "file:slash${/}"
+      },
+      {
+        "regex": "test_envVAR",
+        "uri": "file:${env:HOME}/test.txt"
+      },
+      {
+        "regex": "test_workspaceFolder_Main",
+        "uri": "file:${workspaceFolder:Main Folder}/test.txt"
+      },
+      {
+        "regex": "test_workspaceFolder_Another",
+        "uri": "file:${workspaceFolder:Another Folder}/test.txt"
+      },
+      {
+        "regex": "test_workspaceFolderBasename_Main",
+        "uri": "file:${workspaceFolderBasename:Main Folder}/test.txt"
+      },
+      {
+        "regex": "test_workspaceFolderBasename_Another",
+        "uri": "file:${workspaceFolderBasename:Another Folder}/test.txt"
+      }
+    ],
+  }
+}

--- a/test/single-folder/.vscode/settings.json
+++ b/test/single-folder/.vscode/settings.json
@@ -1,0 +1,41 @@
+{
+  "terminalLinks.matchers": [
+    {
+      "regex": "/(home|opt|Users)\\/[^\\s:]+\\/[^\\s:]+\\.(py|c|rs|cpp)",
+      "uri": "file:${workspaceFolder}/$0"
+    },
+    {
+      "regex": "test_userHome",
+      "uri": "file:${userHome}/test.txt"
+    },
+    {
+      "regex": "test_workspaceFolderBasename",
+      "uri": "file:${workspaceFolderBasename}/test.txt"
+    },
+    {
+      "regex": "test_cwd",
+      "uri": "file:cwd:'${cwd}'/test.txt"
+    },
+    {
+      "regex": "test_pathSeparator",
+      "uri": "file:sep${pathSeparator}"
+    },
+    {
+      "regex": "test_slash",
+      "uri": "file:slash${/}"
+    },
+    {
+      "regex": "test_envVAR",
+      "uri": "file:${env:HOME}/test.txt"
+    },
+    {
+      "regex": "test_workspaceFolder_Single",
+      "uri": "file:${workspaceFolder:single-folder}/test.txt"
+    },
+    {
+      "regex": "test_workspaceFolderBasename_Single",
+      "uri": "file:${workspaceFolderBasename:single-folder}/test.txt"
+    },
+
+  ],
+}

--- a/test/single-folder/.vscode/settings.json
+++ b/test/single-folder/.vscode/settings.json
@@ -13,10 +13,6 @@
       "uri": "file:${workspaceFolderBasename}/test.txt"
     },
     {
-      "regex": "test_cwd",
-      "uri": "file:cwd:'${cwd}'/test.txt"
-    },
-    {
       "regex": "test_pathSeparator",
       "uri": "file:sep${pathSeparator}"
     },


### PR DESCRIPTION
- Updated launch.json to support multifolder and single folder configurations.
- Added multi-folder workspace configuration file with terminal link matchers.
- Added example regexes to test against.
- Made link tooltip rendering show the _URL dedcoded_ URL

This feature is very useful when trying to commit shared rules into a repository, without hard coding a full path.

Fixes #1 