### PR TITLE
Bugfix: support for remotes and devcontainers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,7 @@
 			"request": "launch",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--disable-extension=fractalbrew.terminal-links", // Disable the extension to avoid conflicts
 				"${workspaceFolder}/test/multi-folder/multi-folder-workspace.code-workspace"
 			],
 			"outFiles": [
@@ -24,6 +25,7 @@
 			"request": "launch",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--disable-extension=fractalbrew.terminal-links", // Disable the extension to avoid conflicts
 				"${workspaceFolder}/test/single-folder"
 			],
 			"outFiles": [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "publisher": "fractalbrew",
   "extensionKind": [
-    "ui",
     "workspace"
   ],
   "repository": {


### PR DESCRIPTION
Access to terminal context requires that the extension is running in the same extension host as the workspace. Therefore, we  remove support for installing only on the UI (local) extension host. This PR: 
- Force extension to run on workspace Extension host
- Disables installed extension when testing so don't collide with in-progress extension

Fixes #3 